### PR TITLE
Implementing scheduling task registration and deletion at specific times (Completed)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Django
+my_settings.py
+
 # Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore

--- a/Tom/Tom/ContentView.swift
+++ b/Tom/Tom/ContentView.swift
@@ -11,148 +11,18 @@ import SwiftUI
 import Alamofire
 
 struct ContentView: View {
-    @ObservedObject var you: Networking = Networking()
-    @ObservedObject var jong: Networking = Networking()
-    
-    @State var selectedUser = false
-    @State var selectedYCategories: Int = 0
-    @State var selectedJCategories: Int = 0
-    @State var showDetails = true
-    @State var transition = false
-    @State var alertShowing = false
-    
-    init() {
-        you.getCategories(url: "http://221.159.102.58:8000/api/get/categories", query: ["user": "You"], completion: { (categories) in
-            
-            
-        })
-        
-        jong.getCategories(url: "http://221.159.102.58:8000/api/get/categories", query: ["user": "Jong"], completion: { (categories) in
-            
-            
-        })
-    }
-    
     var body: some View {
         ZStack {
-            VStack {
-                HStack {
-                    Spacer()
-                    
-                    Button(action: {
-                        if selectedUser == false {
-                            you.getCategories(url: "http://221.159.102.58:8000/api/get/categories", query: ["user": "You"], completion: { (categories) in
-                                
-                                
-                            })
-                        } else {
-                            jong.getCategories(url: "http://221.159.102.58:8000/api/get/categories", query: ["user": "Jong"], completion: { (categories) in
-                                
-                                
-                            })
-                        }
-                    }, label: {
-                        if selectedUser == false {
-                            Image(systemName:"arrow.clockwise")
-                                .resizable()
-                                .frame(width: 35.0, height: 40.0)
-                                .foregroundColor(.accentColor)
-                                .padding(5)
-                        } else {
-                            Image(systemName:"arrow.clockwise")
-                                .resizable()
-                                .frame(width: 35.0, height: 40.0)
-                                .foregroundColor(.accentColor)
-                                .padding(5)
-                                .colorInvert()
-                        }
-                            
-                    })
-                }.padding(15.0)
+            TabView {
+                MainView()
+                    .tabItem {
+                        Label("Main", systemImage: "desktopcomputer")
+                    }
                 
-                Spacer()
-            }
-            VStack {
-                
-                Button(action: { if selectedUser == false {
-                    selectedUser = true
-                    showDetails = false
-                    
-                    transition = true
-                    
-                    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
-                        transition = false
+                ScheduleView()
+                    .tabItem {
+                        Label("Schedule", systemImage: "desktopcomputer")
                     }
-                } else {
-                    selectedUser = false
-                    showDetails = true
-                    
-                    transition = true
-                    
-                    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
-                        transition = false
-                    }
-                }}, label: {
-                    if selectedUser == false {
-                        Image("yh")
-                            .imageScale(.large)
-                            .foregroundColor(.accentColor)
-                    } else {
-                        Image("yh")
-                            .imageScale(.large)
-                            .foregroundColor(.accentColor)
-                            .colorInvert()
-                    }
-                }
-                )
-                .disabled(transition)
-                
-                if showDetails {
-                    Picker("", selection: $selectedYCategories) {
-                        ForEach(you.lcategories.indices, id: \.self) { index in Text(you.lcategories[index]) }
-                    }
-                    .pickerStyle(.wheel)
-                    .onChange(of: selectedYCategories, perform: { newValue in print("Selected Unit: \(you.lcategories[newValue])", "Selected Index: \(newValue)")})
-                } else {
-                    Picker("", selection: $selectedJCategories) {
-                        ForEach(jong.lcategories.indices, id: \.self) { index in Text(jong.lcategories[index]) }
-                    }
-                    .pickerStyle(.wheel)
-                    .onChange(of: selectedJCategories, perform: { newValue in print("Selected Unit: \(jong.lcategories[newValue])", "Selected Index: \(newValue)")})
-                }
-                
-                Button(action: {
-                    alertShowing = false
-                    
-                    if selectedUser == false {
-                        you.triggerGIT(url: "http://221.159.102.58:8000/api/trigger/upload/git", bodyl: ["user": "You", "category": you.lcategories[selectedYCategories]], completion: { (results) in
-                            
-                            alertShowing = true
-                            
-                        })
-                    } else {
-                        jong.triggerGIT(url: "http://221.159.102.58:8000/api/trigger/upload/git", bodyl: ["user": "Jong", "category": jong.lcategories[selectedJCategories]], completion: { (results) in
-                            
-                            alertShowing = true
-                            
-                        })
-                    }
-                    
-                })
-                {
-                    HStack {
-                        Image(systemName: "paperplane.fill")
-                        Text("Send")
-                    }.padding(10.0)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 10.0)
-                                .stroke(lineWidth: 2.0)
-                        )
-                }
-                .alert("Success", isPresented: $alertShowing) {
-                    Button("OK", role: .cancel) {  }
-                        .padding()
-                }
             }
         }
     }

--- a/Tom/Tom/MainView.swift
+++ b/Tom/Tom/MainView.swift
@@ -1,0 +1,165 @@
+//
+//  ContentView.swift
+//  Tom
+//
+//  Created by 김종혁 on 2023/10/08.
+//
+
+
+import Foundation
+import SwiftUI
+import Alamofire
+
+struct MainView: View {
+    @ObservedObject var you: Networking = Networking()
+    @ObservedObject var jong: Networking = Networking()
+    
+    @State var selectedUser = false
+    @State var selectedYCategories: Int = 0
+    @State var selectedJCategories: Int = 0
+    @State var showDetails = true
+    @State var transition = false
+    @State var alertShowing = false
+    
+    init() {
+        you.getCategories(url: "http://221.159.102.58:8000/api/get/categories", query: ["user": "You"], completion: { (categories) in
+            
+            
+        })
+        
+        jong.getCategories(url: "http://221.159.102.58:8000/api/get/categories", query: ["user": "Jong"], completion: { (categories) in
+            
+            
+        })
+    }
+    
+    var body: some View {
+        ZStack {
+            VStack {
+                HStack {
+                    Spacer()
+                    
+                    Button(action: {
+                        if selectedUser == false {
+                            you.getCategories(url: "http://221.159.102.58:8000/api/get/categories", query: ["user": "You"], completion: { (categories) in
+                                
+                                
+                            })
+                        } else {
+                            jong.getCategories(url: "http://221.159.102.58:8000/api/get/categories", query: ["user": "Jong"], completion: { (categories) in
+                                
+                                
+                            })
+                        }
+                    }, label: {
+                        if selectedUser == false {
+                            Image(systemName:"arrow.clockwise")
+                                .resizable()
+                                .frame(width: 35.0, height: 40.0)
+                                .foregroundColor(.accentColor)
+                                .padding(5)
+                        } else {
+                            Image(systemName:"arrow.clockwise")
+                                .resizable()
+                                .frame(width: 35.0, height: 40.0)
+                                .foregroundColor(.accentColor)
+                                .padding(5)
+                                .colorInvert()
+                        }
+                            
+                    })
+                }.padding(15.0)
+                
+                Spacer()
+            }
+            VStack {
+                
+                Button(action: { if selectedUser == false {
+                    selectedUser = true
+                    showDetails = false
+                    
+                    transition = true
+                    
+                    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
+                        transition = false
+                    }
+                } else {
+                    selectedUser = false
+                    showDetails = true
+                    
+                    transition = true
+                    
+                    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
+                        transition = false
+                    }
+                }}, label: {
+                    if selectedUser == false {
+                        Image("yh")
+                            .imageScale(.large)
+                            .foregroundColor(.accentColor)
+                    } else {
+                        Image("yh")
+                            .imageScale(.large)
+                            .foregroundColor(.accentColor)
+                            .colorInvert()
+                    }
+                }
+                )
+                .disabled(transition)
+                
+                if showDetails {
+                    Picker("", selection: $selectedYCategories) {
+                        ForEach(you.lcategories.indices, id: \.self) { index in Text(you.lcategories[index]) }
+                    }
+                    .pickerStyle(.wheel)
+                    .onChange(of: selectedYCategories, perform: { newValue in print("Selected Unit: \(you.lcategories[newValue])", "Selected Index: \(newValue)")})
+                } else {
+                    Picker("", selection: $selectedJCategories) {
+                        ForEach(jong.lcategories.indices, id: \.self) { index in Text(jong.lcategories[index]) }
+                    }
+                    .pickerStyle(.wheel)
+                    .onChange(of: selectedJCategories, perform: { newValue in print("Selected Unit: \(jong.lcategories[newValue])", "Selected Index: \(newValue)")})
+                }
+                
+                Button(action: {
+                    alertShowing = false
+                    
+                    if selectedUser == false {
+                        you.triggerGIT(url: "http://221.159.102.58:8000/api/trigger/upload/git", bodyl: ["user": "You", "category": you.lcategories[selectedYCategories]], completion: { (results) in
+                            
+                            alertShowing = true
+                            
+                        })
+                    } else {
+                        jong.triggerGIT(url: "http://221.159.102.58:8000/api/trigger/upload/git", bodyl: ["user": "Jong", "category": jong.lcategories[selectedJCategories]], completion: { (results) in
+                            
+                            alertShowing = true
+                            
+                        })
+                    }
+                    
+                })
+                {
+                    HStack {
+                        Image(systemName: "paperplane.fill")
+                        Text("Send")
+                    }.padding(10.0)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10.0)
+                                .stroke(lineWidth: 2.0)
+                        )
+                }
+                .alert("Success", isPresented: $alertShowing) {
+                    Button("OK", role: .cancel) {  }
+                        .padding()
+                }
+            }
+        }
+    }
+}
+
+struct MainView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainView()
+    }
+}

--- a/Tom/Tom/Model/LScheduledTasks.swift
+++ b/Tom/Tom/Model/LScheduledTasks.swift
@@ -1,0 +1,22 @@
+//
+//  LScheduledTasks.swift
+//  Tom
+//
+//  Created by 김종혁 on 2/1/24.
+//
+
+import Foundation
+
+struct LScheduledTasks: Identifiable, Decodable {
+    var id = UUID()
+    var data: [ScheduledTasks]?
+    
+    enum CodingKeys: CodingKey {
+            case data
+        }
+
+        init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+            data = (try? values.decode([ScheduledTasks].self, forKey: .data)) ?? nil
+        }
+}

--- a/Tom/Tom/Model/RegisterScheduleRequest.swift
+++ b/Tom/Tom/Model/RegisterScheduleRequest.swift
@@ -1,0 +1,23 @@
+//
+//  RegisterSchedule.swift
+//  Tom
+//
+//  Created by 김종혁 on 2/1/24.
+//
+
+import Foundation
+
+struct RegisterScheduleRequest: Identifiable, Codable {
+    var id = UUID()
+    var user: String?
+    var task: String?
+    var scheduled_time: Int?
+}
+
+extension Encodable {
+    var toDictionary : [String: Any]? {
+        guard let object = try? JSONEncoder().encode(self) else { return nil }
+        guard let dictionary = try? JSONSerialization.jsonObject(with: object, options: []) as? [String:Any] else { return nil }
+        return dictionary
+    }
+}

--- a/Tom/Tom/Model/ScheduledTasks.swift
+++ b/Tom/Tom/Model/ScheduledTasks.swift
@@ -1,0 +1,31 @@
+//
+//  ScheduledTasks.swift
+//  Tom
+//
+//  Created by 김종혁 on 2/1/24.
+//
+
+import Foundation
+
+struct ScheduledTasks: Identifiable, Decodable {
+    var id = UUID()
+    var user: String?
+    var task: String?
+    var scheduled_id: String?
+    var scheduled_time: Int?
+    
+    enum CodingKeys: CodingKey {
+            case user
+            case task
+            case scheduled_id
+            case scheduled_time
+        }
+
+        init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+            user = (try? values.decode(String.self, forKey: .user)) ?? nil
+            task = (try? values.decode(String.self, forKey: .task)) ?? nil
+            scheduled_id = (try? values.decode(String.self, forKey: .scheduled_id)) ?? nil
+            scheduled_time = (try? values.decode(Int.self, forKey: .scheduled_time)) ?? nil
+        }
+}

--- a/Tom/Tom/Networking/Networking.swift
+++ b/Tom/Tom/Networking/Networking.swift
@@ -63,5 +63,27 @@ class Networking: ObservableObject {
                     }
         }
     
+    func registerSchedule(url: String, bodyl: Parameters?, completion: @escaping ((String?) -> Void)) {
+            guard let sessionUrl = URL(string: url) else {
+                print("Invalid URL")
+                return
+            }
+        
+            AF.request(sessionUrl,
+                       method: .post,
+                       parameters: bodyl,
+                       encoding: JSONEncoding.default,
+                       headers: ["Content-Type":"application/json", "Accept":"application/json"])
+                .validate(statusCode: 200..<300)
+                .responseDecodable (of: UpResults.self) { response in
+                                switch response.result {
+                                case .success(let value):
+                                    completion(value.results!)
+                                case .failure(let error):
+                                    print(error)
+                            }
+                    }
+        }
+    
     
 }

--- a/Tom/Tom/Networking/Networking.swift
+++ b/Tom/Tom/Networking/Networking.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 class Networking: ObservableObject {
     @Published var lcategories = [String]()
+    @Published var lscheduledTasks = [ScheduledTasks]()
     @Published var ltimes = ["Descheduling", "5 min", "10 min", "15 min", "30 min", "1 hour", "2 hour"]
     @Published var lcatetime: [String: Int] = ["0": 0, "1": 1, "2": 2]
     @Published var selectedLtimesid: Int = 1
@@ -57,6 +58,32 @@ class Networking: ObservableObject {
                                 switch response.result {
                                 case .success(let value):
                                     completion(value.results!)
+                                case .failure(let error):
+                                    print(error)
+                            }
+                    }
+        }
+    
+    func getScheduledTasks(url: String, query: [String: String], completion: @escaping (([ScheduledTasks]?) -> Void)) {
+            guard let sessionUrl = URL(string: url) else {
+                print("Invalid URL")
+                return
+            }
+        
+            AF.request(sessionUrl,
+                       method: .get,
+                       parameters: query,
+                       encoding: URLEncoding.default,
+                       headers: ["Content-Type":"application/json", "Accept":"application/json"])
+                .validate(statusCode: 200..<300)
+                .responseDecodable (of: LScheduledTasks.self) { response in
+                                switch response.result {
+                                case .success(let value):
+                                    self.lscheduledTasks = value.data!
+                                    
+                                    completion(value.data)
+                                    
+                                    print(self.lscheduledTasks)
                                 case .failure(let error):
                                     print(error)
                             }

--- a/Tom/Tom/Networking/Networking.swift
+++ b/Tom/Tom/Networking/Networking.swift
@@ -11,6 +11,9 @@ import SwiftUI
 
 class Networking: ObservableObject {
     @Published var lcategories = [String]()
+    @Published var ltimes = ["Descheduling", "5 min", "10 min", "15 min", "30 min", "1 hour", "2 hour"]
+    @Published var lcatetime: [String: Int] = ["0": 0, "1": 1, "2": 2]
+    @Published var selectedLtimesid: Int = 1
     
     func getCategories(url: String, query: [String: String], completion: @escaping (([String]?) -> Void)) {
             guard let sessionUrl = URL(string: url) else {

--- a/Tom/Tom/ScheduleView.swift
+++ b/Tom/Tom/ScheduleView.swift
@@ -152,14 +152,19 @@ struct ScheduleView: View {
                 Button(action: {
                     alertShowing = false
                     
+                
                     if selectedUser == false {
-                        you.triggerGIT(url: "http://221.159.102.58:8000/api/trigger/upload/git", bodyl: ["user": "You", "category": you.lcategories[selectedYCategories]], completion: { (results) in
+                        let registerScheduleRequest = RegisterScheduleRequest(user: "You", task: you.lcategories[selectedYCategories], scheduled_time: you.selectedLtimesid)
+                        
+                        you.registerSchedule(url: "http://221.159.102.58:8000/api/register/schedule", bodyl: registerScheduleRequest.toDictionary, completion: { (results) in
                             
                             alertShowing = true
                             
                         })
                     } else {
-                        jong.triggerGIT(url: "http://221.159.102.58:8000/api/trigger/upload/git", bodyl: ["user": "Jong", "category": jong.lcategories[selectedJCategories]], completion: { (results) in
+                        let registerScheduleRequest = RegisterScheduleRequest(user: "Jong", task: jong.lcategories[selectedJCategories], scheduled_time: jong.selectedLtimesid)
+                        
+                        jong.registerSchedule(url: "http://221.159.102.58:8000/api/register/schedule", bodyl: registerScheduleRequest.toDictionary, completion: { (results) in
                             
                             alertShowing = true
                             

--- a/Tom/Tom/ScheduleView.swift
+++ b/Tom/Tom/ScheduleView.swift
@@ -26,8 +26,16 @@ struct ScheduleView: View {
             
         })
         
+        you.getScheduledTasks(url: "http://221.159.102.58:8000/api/get/scheduled_tasks", query: ["user": "You"], completion: { (scheduled_tasks) in
+            
+        })
+        
         jong.getCategories(url: "http://221.159.102.58:8000/api/get/categories", query: ["user": "Jong"], completion: { (categories) in
             
+            
+        })
+        
+        jong.getScheduledTasks(url: "http://221.159.102.58:8000/api/get/scheduled_tasks", query: ["user": "Jong"], completion: { (scheduled_tasks) in
             
         })
     }
@@ -113,7 +121,11 @@ struct ScheduleView: View {
                         .pickerStyle(.wheel)
                         .onChange(of: selectedYCategories, perform: { newValue in print("Selected Unit: \(you.lcategories[newValue])", "Selected Index: \(newValue)")
                         
-                            you.selectedLtimesid = you.lcatetime["\(newValue)"] ?? 0
+                            if let scheduledTask = you.lscheduledTasks.last(where: {$0.task == you.lcategories[newValue]}) {
+                                you.selectedLtimesid = Int(scheduledTask.scheduled_time!)
+                            } else {
+                                you.selectedLtimesid = 0
+                            }
                         })
                         .padding(5)
                         
@@ -133,9 +145,13 @@ struct ScheduleView: View {
                         }
                         .pickerStyle(.wheel)
                         .onChange(of: selectedJCategories, perform: { newValue in print("Selected Unit: \(jong.lcategories[newValue])", "Selected Index: \(newValue)")
-                            jong.selectedLtimesid = jong.lcatetime["\(newValue)"] ?? 0
+                            
+                            if let scheduledTask = jong.lscheduledTasks.last(where: {$0.task == jong.lcategories[newValue]}) {
+                                jong.selectedLtimesid = Int(scheduledTask.scheduled_time!)
+                            } else {
+                                jong.selectedLtimesid = 0
+                            }
                         })
-                        
                         .padding(5)
                         
                         Picker("", selection: $jong.selectedLtimesid) {

--- a/Tom/Tom/ScheduleView.swift
+++ b/Tom/Tom/ScheduleView.swift
@@ -8,8 +8,181 @@
 import SwiftUI
 
 struct ScheduleView: View {
+    @ObservedObject var you: Networking = Networking()
+    @ObservedObject var jong: Networking = Networking()
+    
+    @State var selectedUser = false
+    @State var selectedYCategories: Int = 0
+    @State var selectedJCategories: Int = 0
+    @State var selectedYTimes: Int = 0
+    @State var selectedJTimes: Int = 0
+    @State var showDetails = true
+    @State var transition = false
+    @State var alertShowing = false
+    
+    init() {
+        you.getCategories(url: "http://221.159.102.58:8000/api/get/categories", query: ["user": "You"], completion: { (categories) in
+            
+            
+        })
+        
+        jong.getCategories(url: "http://221.159.102.58:8000/api/get/categories", query: ["user": "Jong"], completion: { (categories) in
+            
+            
+        })
+    }
+    
     var body: some View {
-        Text("Schedule View")
+        ZStack {
+            VStack {
+                HStack {
+                    Spacer()
+                    
+                    Button(action: {
+                        if selectedUser == false {
+                            you.getCategories(url: "http://221.159.102.58:8000/api/get/categories", query: ["user": "You"], completion: { (categories) in
+                                
+                                
+                            })
+                        } else {
+                            jong.getCategories(url: "http://221.159.102.58:8000/api/get/categories", query: ["user": "Jong"], completion: { (categories) in
+                                
+                                
+                            })
+                        }
+                    }, label: {
+                        if selectedUser == false {
+                            Image(systemName:"arrow.clockwise")
+                                .resizable()
+                                .frame(width: 35.0, height: 40.0)
+                                .foregroundColor(.accentColor)
+                                .padding(5)
+                        } else {
+                            Image(systemName:"arrow.clockwise")
+                                .resizable()
+                                .frame(width: 35.0, height: 40.0)
+                                .foregroundColor(.accentColor)
+                                .padding(5)
+                                .colorInvert()
+                        }
+                            
+                    })
+                }.padding(15.0)
+                
+                Spacer()
+            }
+            VStack {
+                Button(action: { if selectedUser == false {
+                    selectedUser = true
+                    showDetails = false
+                    
+                    transition = true
+                    
+                    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
+                        transition = false
+                    }
+                } else {
+                    selectedUser = false
+                    showDetails = true
+                    
+                    transition = true
+                    
+                    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
+                        transition = false
+                    }
+                }}, label: {
+                    if selectedUser == false {
+                        Image("yh")
+                            .imageScale(.large)
+                            .foregroundColor(.accentColor)
+                    } else {
+                        Image("yh")
+                            .imageScale(.large)
+                            .foregroundColor(.accentColor)
+                            .colorInvert()
+                    }
+                }
+                )
+                .disabled(transition)
+                
+                if showDetails {
+                    HStack {
+                        Picker("", selection: $selectedYCategories) {
+                            ForEach(you.lcategories.indices, id: \.self) { index in Text(you.lcategories[index]) }
+                        }
+                        .pickerStyle(.wheel)
+                        .onChange(of: selectedYCategories, perform: { newValue in print("Selected Unit: \(you.lcategories[newValue])", "Selected Index: \(newValue)")
+                        
+                            you.selectedLtimesid = you.lcatetime["\(newValue)"] ?? 0
+                        })
+                        .padding(5)
+                        
+                        Picker("", selection: $you.selectedLtimesid) {
+                            ForEach(you.ltimes.indices, id: \.self) { index in Text(you.ltimes[index]) }
+                        }
+                        .pickerStyle(.wheel)
+                        .onChange(of: you.selectedLtimesid, perform: { newValue in
+                            print(newValue)
+                        })
+                        .padding(5)
+                    }
+                } else {
+                    HStack {
+                        Picker("", selection: $selectedJCategories) {
+                            ForEach(jong.lcategories.indices, id: \.self) { index in Text(jong.lcategories[index]) }
+                        }
+                        .pickerStyle(.wheel)
+                        .onChange(of: selectedJCategories, perform: { newValue in print("Selected Unit: \(jong.lcategories[newValue])", "Selected Index: \(newValue)")
+                            jong.selectedLtimesid = jong.lcatetime["\(newValue)"] ?? 0
+                        })
+                        
+                        .padding(5)
+                        
+                        Picker("", selection: $jong.selectedLtimesid) {
+                            ForEach(jong.ltimes.indices, id: \.self) { index in Text(jong.ltimes[index]) }
+                        }
+                        .onChange(of: jong.selectedLtimesid, perform: { newValue in
+                            print(newValue)
+                        })
+                        .pickerStyle(.wheel)
+                        .padding(5)
+                    }
+                }
+                
+                Button(action: {
+                    alertShowing = false
+                    
+                    if selectedUser == false {
+                        you.triggerGIT(url: "http://221.159.102.58:8000/api/trigger/upload/git", bodyl: ["user": "You", "category": you.lcategories[selectedYCategories]], completion: { (results) in
+                            
+                            alertShowing = true
+                            
+                        })
+                    } else {
+                        jong.triggerGIT(url: "http://221.159.102.58:8000/api/trigger/upload/git", bodyl: ["user": "Jong", "category": jong.lcategories[selectedJCategories]], completion: { (results) in
+                            
+                            alertShowing = true
+                            
+                        })
+                    }
+                    
+                })
+                {
+                    HStack {
+                        Image(systemName: "paperplane.fill")
+                        Text("Send")
+                    }.padding(10.0)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10.0)
+                                .stroke(lineWidth: 2.0)
+                        )
+                }
+                .alert("Success", isPresented: $alertShowing) {
+                    Button("OK", role: .cancel) {  }
+                        .padding()
+                }
+            }
+        }
     }
 }
 

--- a/Tom/Tom/ScheduleView.swift
+++ b/Tom/Tom/ScheduleView.swift
@@ -1,0 +1,20 @@
+//
+//  ScheduleView.swift
+//  Tom
+//
+//  Created by 김종혁 on 2/1/24.
+//
+
+import SwiftUI
+
+struct ScheduleView: View {
+    var body: some View {
+        Text("Schedule View")
+    }
+}
+
+struct ScheduleView_Previews: PreviewProvider {
+    static var previews: some View {
+        ScheduleView()
+    }
+}

--- a/YouHyeok/Tom/models.py
+++ b/YouHyeok/Tom/models.py
@@ -1,3 +1,10 @@
 from django.db import models
 
 # Create your models here.
+class SchedulingTasks(models.Model):
+    user = models.CharField(max_length = 20, null=True)
+    task = models.CharField(max_length = 20, null=True)
+    scheduled_id = models.CharField(max_length = 40, null=True)
+    scheduled_time = models.IntegerField(null=True)
+    created_date = models.DateField(auto_now_add=True)
+    modified_date = models.DateField(auto_now=True)

--- a/YouHyeok/Tom/serializers.py
+++ b/YouHyeok/Tom/serializers.py
@@ -1,1 +1,12 @@
 from rest_framework import serializers
+from Tom.models import SchedulingTasks
+
+class SchedulingSerializer(serializers.ModelSerializer):
+    user = serializers.CharField(max_length = 20)
+    task = serializers.CharField(max_length = 20)
+    scheduled_id = serializers.CharField(max_length = 40)
+    scheduled_time = serializers.IntegerField()
+
+    class Meta:
+        model = SchedulingTasks
+        fields = ("user", "task", "scheduled_id", "scheduled_time")

--- a/YouHyeok/Tom/tasks.py
+++ b/YouHyeok/Tom/tasks.py
@@ -1,0 +1,20 @@
+import os
+import json
+
+from django.conf import settings
+from celery import shared_task
+
+users_repo = {"Jong": ["_tutorials", "_labs", "_enfycius"], "You": ["newblog"]}
+
+@shared_task()
+def git_task(user, task):
+    repos = users_repo[user]
+    category = task.split('-')[1]
+    repo = task.split('-')[0]
+
+    if repo in repos:
+        with open('/root/Repos/%s/package.json' % repo) as f:
+            json_object = json.load(f)
+
+            os.system("cd /root/Repos/%s/ && git config --local user.name \"%s\" && git config --local user.email \"%s\"" % (repo, json_object['scripts']['user_name'], json_object['scripts']['user_email']))
+            os.system("cd /root/Repos/%s/ && npm run %s" % (repo, category))

--- a/YouHyeok/Tom/urls.py
+++ b/YouHyeok/Tom/urls.py
@@ -9,5 +9,6 @@ import Tom.views
 urlpatterns = [
     path("get/categories", Tom.views.index, name='Get Categories'),
     path("get/scheduled_tasks", Tom.views.scheduled_tasks, name="Get Scheduled Tasks"),
-    path("trigger/upload/git", Tom.views.git, name="Trigger Uploading to GIT")
+    path("trigger/upload/git", Tom.views.git, name="Trigger Uploading to GIT"),
+    path("register/schedule", Tom.views.register_schedule, name="Registering the requested schedule")
 ] 

--- a/YouHyeok/Tom/urls.py
+++ b/YouHyeok/Tom/urls.py
@@ -7,6 +7,7 @@ from django.conf.urls.static import static
 import Tom.views
 
 urlpatterns = [
-    path("get/categories", Tom.views.index, name='Categories'),
+    path("get/categories", Tom.views.index, name='Get Categories'),
+    path("get/scheduled_tasks", Tom.views.scheduled_tasks, name="Get Scheduled Tasks"),
     path("trigger/upload/git", Tom.views.git, name="Trigger Uploading to GIT")
 ] 

--- a/YouHyeok/Tom/views.py
+++ b/YouHyeok/Tom/views.py
@@ -58,16 +58,28 @@ def index(request):
 
 @api_view(['GET'])
 def scheduled_tasks(request):
-    scheduled_tasks = SchedulingTasks.objects.all()
+    if request.GET.get('user', None) != None:
+        if request.GET.get('user', None) == 'You':
+            scheduled_tasks = SchedulingTasks.objects.filter(user = 'You')
+            scheduled_tasks = [model_to_dict(obj) for obj in scheduled_tasks]
 
-    scheduled_tasks = [model_to_dict(obj) for obj in scheduled_tasks]
+            serializer = SchedulingSerializer(data = scheduled_tasks, many = True)
 
-    serializer = SchedulingSerializer(data = scheduled_tasks, many = True)
+            if serializer.is_valid():
+                return Response({"status": "success", "data": serializer.data})
+            else:
+                return Response({"status": "error", "data": serializer.errors})
+            
+        elif request.GET.get('user', None) == 'Jong':
+            scheduled_tasks = SchedulingTasks.objects.filter(user = 'Jong')
+            scheduled_tasks = [model_to_dict(obj) for obj in scheduled_tasks]
 
-    if serializer.is_valid():
-        return Response({"status": "success", "data": serializer.data})
-    else:
-        return Response({"status": "error", "data": serializer.errors})
+            serializer = SchedulingSerializer(data = scheduled_tasks, many = True)
+
+            if serializer.is_valid():
+                return Response({"status": "success", "data": serializer.data})
+            else:
+                return Response({"status": "error", "data": serializer.errors})
 
 def register_periodic_task(scheduled_time, user, task):
     schedule, created = IntervalSchedule.objects.get_or_create(

--- a/YouHyeok/Tom/views.py
+++ b/YouHyeok/Tom/views.py
@@ -6,13 +6,18 @@ import json
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 
+from Tom.models import SchedulingTasks
+from Tom.serializers import SchedulingSerializer
+
 from django.conf import settings
 
 from pathlib import Path
 
+from django.forms.models import model_to_dict
+
 # Create your views here.
 
-users_repo = {"Jong": ["_tutorials", "_labs"], "You": ["newblog"]}
+users_repo = {"Jong": ["_tutorials", "_labs", "_enfycius"], "You": ["newblog"]}
 
 @api_view(['GET'])
 def index(request):
@@ -21,7 +26,6 @@ def index(request):
         if request.GET.get('user', None) == 'You':
             repos = users_repo[request.GET.get('user', None)]
             categories = []
-
 
             for repo in repos:
                 with open('/root/Repos/%s/package.json' % repo) as f:
@@ -46,6 +50,19 @@ def index(request):
                             categories.append(repo + "-" + key)
                         
             return Response({"results": categories})
+
+@api_view(['GET'])
+def scheduled_tasks(request):
+    scheduled_tasks = SchedulingTasks.objects.all()
+
+    scheduled_tasks = [model_to_dict(obj) for obj in scheduled_tasks]
+
+    serializer = SchedulingSerializer(data = scheduled_tasks, many = True)
+
+    if serializer.is_valid():
+        return Response({"status": "success", "data": serializer.data})
+    else:
+        return Response({"status": "error", "data": serializer.errors})
 
 @api_view(['POST'])
 def git(request):

--- a/YouHyeok/YouHyeok/celery.py
+++ b/YouHyeok/YouHyeok/celery.py
@@ -1,0 +1,20 @@
+import sys
+
+import os
+from celery import Celery
+
+CURRENT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, CURRENT_DIR)
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'YouHyeok.settings')
+
+app = Celery('YouHyeok', include=['Tom.tasks'])
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+app.conf.update(
+    CELERY_BROKER_URL = 'pyamqp://guest@localhost//',
+    CELERY_RESULT_BACKEND = "redis://youhyeok.com:6379",
+    CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler',
+)
+
+app.autodiscover_tasks([])

--- a/YouHyeok/YouHyeok/settings.py
+++ b/YouHyeok/YouHyeok/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
+import my_settings
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -40,6 +41,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    'django_celery_beat',
     'Tom',
     'rest_framework',
     'corsheaders',
@@ -80,13 +82,7 @@ WSGI_APPLICATION = "YouHyeok.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    }
-}
-
+DATABASES = my_settings.DATABASES
 
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators


### PR DESCRIPTION
- Using the TabView (Bottom Navigation Bar) to Split Views
- Code Refactoring & UI changes for the Schedule View
- Registering gitignore for the my_settings.py file and linking to the database
- Defining a model
- Defining a Serializers
- Defining an endpoint
- Implementing code to get a list of scheduling tasks from a database
- Correcting typos
- Overriding an existing model
- Overriding an existing serializer
- Adding django_celery_beat
- Overriding an existing model
- Overriding an existing serializer
- Define a model for Alamofire parameters to register a schedule, make POST requests to the server, and fix UI errors
- Define an endpoint
- Setting up Celery
- Defining tasks
- Finished processing and implemented requests for schedule registration
- Passing a query on a GET request
- Define a model for receiving ScheduledTasks from the server
- Implement networking code to receive ScheduledTasks from the server
- Get ScheduleTasks from the server and apply them to an existing view, fix #31
